### PR TITLE
Auto-refresh results every 5 seconds while tab is open

### DIFF
--- a/gender-reveal.html
+++ b/gender-reveal.html
@@ -470,9 +470,16 @@
   })();
 
   // ── Screen helpers ───────────────────────────────────────────────────────────
+  var refreshTimer = null;
+
   function showScreen(id) {
     document.querySelectorAll('.screen').forEach(function (s) { s.classList.remove('active'); });
     document.getElementById(id).classList.add('active');
+
+    clearInterval(refreshTimer);
+    if (id === 'screen-result') {
+      refreshTimer = setInterval(fetchCounts, 5000);
+    }
   }
 
   function goToVote() {


### PR DESCRIPTION
Starts a 5-second polling interval whenever the results screen is shown, and clears it when navigating away. New votes and names appear automatically without tapping Refresh.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWEuKUDrQhdUhatQuiUmKG)_