### PR TITLE
Show achievement badge in mobile top nav

### DIFF
--- a/css/resume.css
+++ b/css/resume.css
@@ -856,3 +856,12 @@ html[data-theme="retro"] .ach-title { color: #00ff41; text-shadow: 0 0 6px rgba(
 
 [data-theme="dark"] .ach-item.unlocked { background: rgba(226,123,53,0.12); }
 [data-theme="dark"] .ach-item.locked   { background: rgba(255,255,255,0.04); }
+
+/* Mobile achievement badge in top nav */
+.ach-progress-mob {
+  margin: 0 0.3rem;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.78rem;
+  background: rgba(255,255,255,0.15);
+  border-color: rgba(255,255,255,0.25);
+}

--- a/index.html
+++ b/index.html
@@ -58,6 +58,10 @@
            alt="Prashanth Naika">
     </span>
   </a>
+  <!-- Mobile: achievement badge in top bar -->
+  <button class="ach-progress-btn ach-progress-mob d-lg-none" id="ach-progress-btn-mob" title="Achievements">
+    🏆 <span id="ach-count-mob">0</span>/<span>16</span>
+  </button>
   <!-- Mobile: modes dropdown in top bar -->
   <div class="mode-dd d-lg-none ms-auto" id="mode-dd-mob">
     <button class="mode-dd-mob-btn" id="mode-btn-mob" aria-label="Switch mode">
@@ -116,8 +120,8 @@
       </div>
     </div>
 
-    <!-- Achievements badge -->
-    <button class="ach-progress-btn" id="ach-progress-btn" title="Achievements">
+    <!-- Achievements badge (desktop sidebar) -->
+    <button class="ach-progress-btn d-none d-lg-flex" id="ach-progress-btn" title="Achievements">
       🏆 <span id="ach-count">0</span> / 16
     </button>
   </div>

--- a/js/achievements.js
+++ b/js/achievements.js
@@ -80,8 +80,11 @@
   // ─── Progress badge & panel ────────────────────────────────────────────────
 
   function updateBadge() {
-    var el = document.getElementById('ach-count');
-    if (el) el.textContent = unlocked.length;
+    var n = unlocked.length;
+    ['ach-count', 'ach-count-mob'].forEach(function (id) {
+      var el = document.getElementById(id);
+      if (el) el.textContent = n;
+    });
   }
 
   function renderPanel() {
@@ -104,13 +107,17 @@
     });
   }
 
+  function openPanel() {
+    renderPanel();
+    document.getElementById('ach-panel').classList.add('open');
+    document.getElementById('ach-panel-overlay').classList.add('open');
+  }
+
   document.addEventListener('DOMContentLoaded', function () {
     updateBadge();
-    var btn = document.getElementById('ach-progress-btn');
-    if (btn) btn.addEventListener('click', function () {
-      renderPanel();
-      document.getElementById('ach-panel').classList.add('open');
-      document.getElementById('ach-panel-overlay').classList.add('open');
+    ['ach-progress-btn', 'ach-progress-btn-mob'].forEach(function (id) {
+      var btn = document.getElementById(id);
+      if (btn) btn.addEventListener('click', openPanel);
     });
   });
 


### PR DESCRIPTION
Adds a compact `🏆 X/16` button to the mobile top bar (between the modes icon and the hamburger), so the achievement counter is always visible on phones. The desktop sidebar badge is unchanged. Both buttons open the same slide-in panel and stay in sync.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWEuKUDrQhdUhatQuiUmKG)_